### PR TITLE
Extend default native fields option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+vendor/

--- a/acf-native-field-type.php
+++ b/acf-native-field-type.php
@@ -34,17 +34,49 @@ class acf_field_native extends acf_field {
 				'required'     => 1,
 				// TODO: Implement backend and frontend functionality for custom native fields (hooks)
 				'choices'      => array(
-					'content'         => __( 'Content Editor', 'acf-native-fields' ),
-					'excerpt'         => __( 'Excerpt', 'acf-native-fields' ),
-					'featured_image'  => __( 'Featured Image', 'acf-native-fields' ),
-					'yoast_seo'       => __( 'SEO (Yoast or SEO framework)', 'acf-native-fields' ),
-					'publish_box'     => __( 'Publish Box', 'acf-native-fields' ),
-					'permalink'       => __( 'Permalink', 'acf-native-fields' ),
-					'discussion'      => __( 'Discussion', 'acf-native-fields' ),
-					'trackbacks'      => __( 'Trackbacks', 'acf-native-fields' ),
-					'format'          => __( 'Format', 'acf-native-fields' ),
-					'page_attributes' => __( 'Page Attributes', 'acf-native-fields' ),
-					'custom'          => __( 'Custom', 'acf-native-fields' ),
+					'Core'        => array(
+						'content'         => __( 'Content Editor', 'acf-native-fields' ),
+						'excerpt'         => __( 'Excerpt', 'acf-native-fields' ),
+						'publish_box'     => __( 'Publish Box', 'acf-native-fields' ),
+						'page_attributes' => __( 'Page Attributes', 'acf-native-fields' ),
+						'featured_image'  => __( 'Featured Image', 'acf-native-fields' ),
+
+						'permalink'       => __( 'Permalink', 'acf-native-fields' ),
+						'author'          => __( 'Author', 'acf-native-fields' ),
+
+						'categories'      => __( 'Categories', 'acf-native-fields' ),
+						'tags'            => __( 'Tags', 'acf-native-fields' ),
+						'format'          => __( 'Format', 'acf-native-fields' ),
+
+						'revisions'       => __( 'Revisions', 'acf-native-fields' ),
+						'comments'        => __( 'Comments', 'acf-native-fields' ),
+						'discussion'      => __( 'Discussion', 'acf-native-fields' ),
+						'trackbacks'      => __( 'Trackbacks', 'acf-native-fields' ),
+					),
+
+					'WooCommerce' => array(
+						// TODO: Check if installed
+						'all'                       => __( 'All', 'acf-native-fields' ),
+						'product_categories'        => __( 'Product Categories', 'acf-native-fields' ),
+						'product_tags'              => __( 'Product Tags', 'acf-native-fields' ),
+						'product_image'             => __( 'Product Image', 'acf-native-fields' ),
+						'product_gallery'           => __( 'Product Gallery', 'acf-native-fields' ),
+						'product_data'              => __( 'Product Data', 'acf-native-fields' ),
+						'product_short_description' => __( 'Product Short Description', 'acf-native-fields' ),
+						'reviews'                   => __( 'Reviews', 'acf-native-fields' ),
+					),
+
+					'Plugins'     => array(
+						// TODO: Check if plugins are installed
+						'yoast_seo'      => __( 'Yoast SEO', 'acf-native-fields' ),
+						'seo_framework'  => __( 'SEO Framework', 'acf-native-fields' ),
+						'classic_editor' => __( 'Classic Editor (Editor Switcher)', 'acf-native-fields' ),
+						'laygridder'     => __( 'LayGridder', 'acf-native-fields' ),
+					),
+
+					'Other'       => array(
+						'custom' => __( 'Custom', 'acf-native-fields' ),
+					),
 				),
 			)
 		);

--- a/acf-native-field-type.php
+++ b/acf-native-field-type.php
@@ -52,11 +52,10 @@ class acf_field_native extends acf_field {
 		acf_render_field_setting(
 			$field,
 			array(
-				'label'             => __( 'Custom Meta Box ID', 'acf-native-fields' ),
-				'instructions'      => __( 'The ID of the custom metabox to target.', 'acf-native-fields' ),
+				'label'             => __( 'Custom Meta Box', 'acf-native-fields' ),
+				'instructions'      => __( 'A valid CSS selector to target your desired meta box.', 'acf-native-fields' ),
 				'type'              => 'text',
 				'name'              => 'metabox_id',
-				'prefix'            => '#',
 				'conditional_logic' => array(
 					array(
 						array(

--- a/acf-native-field-type.php
+++ b/acf-native-field-type.php
@@ -24,6 +24,11 @@ class acf_field_native extends acf_field {
 	}
 
 	function render_field_settings( $field ) {
+		$active_plugins = apply_filters( 'active_plugins', get_option( 'active_plugins' ) );
+		$is_active      = function ( $plugin ) use ( $active_plugins ) {
+			return in_array( $plugin, $active_plugins, true );
+		};
+
 		acf_render_field_setting(
 			$field,
 			array(
@@ -33,50 +38,52 @@ class acf_field_native extends acf_field {
 				'name'         => 'native_field',
 				'required'     => 1,
 				// TODO: Implement backend and frontend functionality for custom native fields (hooks)
-				'choices'      => array(
-					'Core'        => array(
-						'content'         => __( 'Content Editor', 'acf-native-fields' ),
-						'excerpt'         => __( 'Excerpt', 'acf-native-fields' ),
-						'publish_box'     => __( 'Publish Box', 'acf-native-fields' ),
-						'page_attributes' => __( 'Page Attributes', 'acf-native-fields' ),
-						'featured_image'  => __( 'Featured Image', 'acf-native-fields' ),
+				'choices'      => array_filter(
+					array(
+						'Core'        => array(
+							'content'         => __( 'Content Editor', 'acf-native-fields' ),
+							'excerpt'         => __( 'Excerpt', 'acf-native-fields' ),
+							'publish_box'     => __( 'Publish Box', 'acf-native-fields' ),
+							'page_attributes' => __( 'Page Attributes', 'acf-native-fields' ),
+							'featured_image'  => __( 'Featured Image', 'acf-native-fields' ),
 
-						'permalink'       => __( 'Permalink', 'acf-native-fields' ),
-						'author'          => __( 'Author', 'acf-native-fields' ),
+							'permalink'       => __( 'Permalink', 'acf-native-fields' ),
+							'author'          => __( 'Author', 'acf-native-fields' ),
 
-						'categories'      => __( 'Categories', 'acf-native-fields' ),
-						'tags'            => __( 'Tags', 'acf-native-fields' ),
-						'format'          => __( 'Format', 'acf-native-fields' ),
+							'categories'      => __( 'Categories', 'acf-native-fields' ),
+							'tags'            => __( 'Tags', 'acf-native-fields' ),
+							'format'          => __( 'Format', 'acf-native-fields' ),
 
-						'revisions'       => __( 'Revisions', 'acf-native-fields' ),
-						'comments'        => __( 'Comments', 'acf-native-fields' ),
-						'discussion'      => __( 'Discussion', 'acf-native-fields' ),
-						'trackbacks'      => __( 'Trackbacks', 'acf-native-fields' ),
-					),
+							'revisions'       => __( 'Revisions', 'acf-native-fields' ),
+							'comments'        => __( 'Comments', 'acf-native-fields' ),
+							'discussion'      => __( 'Discussion', 'acf-native-fields' ),
+							'trackbacks'      => __( 'Trackbacks', 'acf-native-fields' ),
+						),
 
-					'WooCommerce' => array(
-						// TODO: Check if installed
-						'all'                       => __( 'All', 'acf-native-fields' ),
-						'product_categories'        => __( 'Product Categories', 'acf-native-fields' ),
-						'product_tags'              => __( 'Product Tags', 'acf-native-fields' ),
-						'product_image'             => __( 'Product Image', 'acf-native-fields' ),
-						'product_gallery'           => __( 'Product Gallery', 'acf-native-fields' ),
-						'product_data'              => __( 'Product Data', 'acf-native-fields' ),
-						'product_short_description' => __( 'Product Short Description', 'acf-native-fields' ),
-						'reviews'                   => __( 'Reviews', 'acf-native-fields' ),
-					),
+						'WooCommerce' => $is_active( 'woocommerce/woocommerce.php' ) ? array(
+							'all'                       => __( 'All', 'acf-native-fields' ),
+							'product_categories'        => __( 'Product Categories', 'acf-native-fields' ),
+							'product_tags'              => __( 'Product Tags', 'acf-native-fields' ),
+							'product_image'             => __( 'Product Image', 'acf-native-fields' ),
+							'product_gallery'           => __( 'Product Gallery', 'acf-native-fields' ),
+							'product_data'              => __( 'Product Data', 'acf-native-fields' ),
+							'product_short_description' => __( 'Product Short Description', 'acf-native-fields' ),
+							'reviews'                   => __( 'Reviews', 'acf-native-fields' ),
+						) : false,
 
-					'Plugins'     => array(
-						// TODO: Check if plugins are installed
-						'yoast_seo'      => __( 'Yoast SEO', 'acf-native-fields' ),
-						'seo_framework'  => __( 'SEO Framework', 'acf-native-fields' ),
-						'classic_editor' => __( 'Classic Editor (Editor Switcher)', 'acf-native-fields' ),
-						'laygridder'     => __( 'LayGridder', 'acf-native-fields' ),
-					),
+						'Plugins'     => array_filter(
+							array(
+								'yoast_seo'      => $is_active( 'wordpress-seo/wp-seo.php' ) ? __( 'Yoast SEO', 'acf-native-fields' ) : false,
+								'seo_framework'  => $is_active( 'autodescription/autodescription.php' ) ? __( 'SEO Framework', 'acf-native-fields' ) : false,
+								'classic_editor' => $is_active( 'classic-editor/classic-editor.php' ) ? __( 'Classic Editor (Editor Switcher)', 'acf-native-fields' ) : false,
+								'laygridder'     => $is_active( 'laygridder/laygridder.php' ) ? __( 'LayGridder', 'acf-native-fields' ) : false,
+							)
+						),
 
-					'Other'       => array(
-						'custom' => __( 'Custom', 'acf-native-fields' ),
-					),
+						'Other'       => array(
+							'custom' => __( 'Custom', 'acf-native-fields' ),
+						),
+					)
 				),
 			)
 		);

--- a/acf-native-field-type.php
+++ b/acf-native-field-type.php
@@ -1,79 +1,93 @@
 <?php
-if(!defined('ABSPATH')) exit;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 class acf_field_native extends acf_field {
 	function __construct() {
 		$this->name = 'native_field';
 
-		$this->label = __('Native Field', 'acf-native-fields');
+		$this->label = __( 'Native Field', 'acf-native-fields' );
 
 		$this->defaults = array(
-			'value'			=> false, // prevents acf_render_fields() from attempting to load value
+			'value' => false, // prevents acf_render_fields() from attempting to load value
 		);
-		
+
 		$this->category = 'layout';
-		
+
 		$this->l10n = array(
-			'not_implemented' => __('Native Field not implemented yet.', 'acf-native-fields'),
+			'not_implemented' => __( 'Native Field not implemented yet.', 'acf-native-fields' ),
 		);
 
-    	parent::__construct();
+		parent::__construct();
 	}
-	
-	function render_field_settings($field) {
-		acf_render_field_setting($field, array(
-			'label'			=> __('Native Field', 'acf-native-fields'),
-			'instructions'	=> __('The native WordPress field to move into this placeholder.', 'acf-native-fields'),
-			'type'			=> 'select',
-			'name'			=> 'native_field',
-			'required'		=> 1,
-			// TODO: Implement backend and frontend functionality for custom native fields (hooks)
-			'choices'		=> array(
-				'content'		  => __('Content Editor', 'acf-native-fields'),
-				'excerpt'		  => __('Excerpt', 'acf-native-fields'),
-				'featured_image'  => __('Featured Image', 'acf-native-fields'),
-				'yoast_seo'		  => __('SEO (Yoast or SEO framework)', 'acf-native-fields'),
-				'publish_box'	  => __('Publish Box', 'acf-native-fields'),
-				'permalink'	 	  => __('Permalink', 'acf-native-fields'),
-				'discussion'	  => __('Discussion', 'acf-native-fields'),
-				'trackbacks'	  => __('Trackbacks', 'acf-native-fields'),
-				'format'		  => __('Format', 'acf-native-fields'),
-				'page_attributes' => __('Page Attributes', 'acf-native-fields'),
-				'custom'		  => __('Custom', 'acf-native-fields'),
-			),
-		));
 
-		acf_render_field_setting($field, array(
-			'label'				=> __('Custom Meta Box ID', 'acf-native-fields'),
-			'instructions'		=> __('The ID of the custom metabox to target.', 'acf-native-fields'),
-			'type'				=> 'text',
-			'name'				=> 'metabox_id',
-			'prefix'			=> '#',
-			'conditional_logic' => array(
-				array(
+	function render_field_settings( $field ) {
+		acf_render_field_setting(
+			$field,
+			array(
+				'label'        => __( 'Native Field', 'acf-native-fields' ),
+				'instructions' => __( 'The native WordPress field to move into this placeholder.', 'acf-native-fields' ),
+				'type'         => 'select',
+				'name'         => 'native_field',
+				'required'     => 1,
+				// TODO: Implement backend and frontend functionality for custom native fields (hooks)
+				'choices'      => array(
+					'content'         => __( 'Content Editor', 'acf-native-fields' ),
+					'excerpt'         => __( 'Excerpt', 'acf-native-fields' ),
+					'featured_image'  => __( 'Featured Image', 'acf-native-fields' ),
+					'yoast_seo'       => __( 'SEO (Yoast or SEO framework)', 'acf-native-fields' ),
+					'publish_box'     => __( 'Publish Box', 'acf-native-fields' ),
+					'permalink'       => __( 'Permalink', 'acf-native-fields' ),
+					'discussion'      => __( 'Discussion', 'acf-native-fields' ),
+					'trackbacks'      => __( 'Trackbacks', 'acf-native-fields' ),
+					'format'          => __( 'Format', 'acf-native-fields' ),
+					'page_attributes' => __( 'Page Attributes', 'acf-native-fields' ),
+					'custom'          => __( 'Custom', 'acf-native-fields' ),
+				),
+			)
+		);
+
+		acf_render_field_setting(
+			$field,
+			array(
+				'label'             => __( 'Custom Meta Box ID', 'acf-native-fields' ),
+				'instructions'      => __( 'The ID of the custom metabox to target.', 'acf-native-fields' ),
+				'type'              => 'text',
+				'name'              => 'metabox_id',
+				'prefix'            => '#',
+				'conditional_logic' => array(
 					array(
-						'field' => 'native_field',
-						'operator' => '==',
-						'value' => 'custom',
+						array(
+							'field'    => 'native_field',
+							'operator' => '==',
+							'value'    => 'custom',
+						),
 					),
 				),
-			),
-		));
+			)
+		);
 	}
-	
-	function render_field($field) {?>
-		<div class="acf-native-field" data-native-field="<?php echo esc_attr($field['native_field']); ?>"<?php echo (!empty($field['metabox_id']) ? ' data-metabox-id="' . esc_attr($field['metabox_id']) . '"' : ''); ?>>
-			<?php _e('Loading...', 'acf-native-fields'); ?>
-		</div><?php
+
+	function render_field( $field ) {?>
+		<div class="acf-native-field" data-native-field="<?php echo esc_attr( $field['native_field'] ); ?>"<?php echo ( ! empty( $field['metabox_id'] ) ? ' data-metabox-id="' . esc_attr( $field['metabox_id'] ) . '"' : '' ); ?>>
+			<?php esc_html_e( 'Loading…', 'acf-native-fields' ); ?>
+		</div>
+		<?php
 	}
-	
+
 	function input_admin_enqueue_scripts() {
-		wp_enqueue_script('acf-native-fields', plugins_url('/js/acf-native-fields.js', __FILE__), array('jquery'), ACF_Native_Fields::instance()->plugin_data['Version']);
-		wp_enqueue_style('acf-native-fields', plugins_url('/css/acf-native-fields.css', __FILE__), array(), ACF_Native_Fields::instance()->plugin_data['Version']);
+		$plugin_version = ACF_Native_Fields::instance()->plugin_data['Version'];
+
+		wp_enqueue_script( 'acf-native-fields', plugins_url( '/js/acf-native-fields.js', __FILE__ ), array( 'jquery' ), $plugin_version, false );
+		wp_enqueue_style( 'acf-native-fields', plugins_url( '/css/acf-native-fields.css', __FILE__ ), array(), $plugin_version );
 	}
 
 	function field_group_admin_enqueue_scripts() {
-		wp_enqueue_script('acf-native-fields-admin', plugins_url('/js/acf-native-fields-admin.js', __FILE__), array('jquery'), ACF_Native_Fields::instance()->plugin_data['Version']);
-		wp_enqueue_style('acf-native-fields-admin', plugins_url('/css/acf-native-fields-admin.css', __FILE__), array(), ACF_Native_Fields::instance()->plugin_data['Version']);
+		$plugin_version = ACF_Native_Fields::instance()->plugin_data['Version'];
+
+		wp_enqueue_script( 'acf-native-fields-admin', plugins_url( '/js/acf-native-fields-admin.js', __FILE__ ), array( 'jquery' ), $plugin_version, false );
+		wp_enqueue_style( 'acf-native-fields-admin', plugins_url( '/css/acf-native-fields-admin.css', __FILE__ ), array(), $plugin_version );
 	}
 }

--- a/acf-native-fields.php
+++ b/acf-native-fields.php
@@ -10,54 +10,57 @@ License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.en.html
 */
 
-if(!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 class ACF_Native_Fields {
-	static $instance = false; 
-	
+	static $instance = false;
+
 	public $plugin_data = null;
-	
+
 	function __construct() {
 		// Init plugin (check requirements etc)
-		add_action('admin_init', array($this, 'admin_init'));
-		
-		// Add native field type to ACF
-		add_action('acf/include_field_types', array($this, 'include_native_field_type'));
-	}
-	
-	public function admin_init() {
-		load_plugin_textdomain('acf-native-fields', false, dirname(plugin_basename(__FILE__)) . '/lang/'); 
-		
-		$this->plugin_data = get_plugin_data(dirname(__FILE__));
-		
-		// Require ACF
-		if (current_user_can('activate_plugins') && !is_plugin_active('advanced-custom-fields/acf.php') && !is_plugin_active('advanced-custom-fields-pro/acf.php')) {
-			add_action('admin_notices', array($this, 'require_acf'));
-			deactivate_plugins(plugin_basename( __FILE__ )); 
+		add_action( 'admin_init', array( $this, 'admin_init' ) );
 
-			if(isset($_GET['activate'])) {
-				unset($_GET['activate']);
+		// Add native field type to ACF
+		add_action( 'acf/include_field_types', array( $this, 'include_native_field_type' ) );
+	}
+
+	public function admin_init() {
+		load_plugin_textdomain( 'acf-native-fields', false, dirname( plugin_basename( __FILE__ ) ) . '/lang/' );
+
+		$this->plugin_data = get_plugin_data( dirname( __FILE__ ) );
+
+		// Require ACF
+		if ( current_user_can( 'activate_plugins' ) && ! is_plugin_active( 'advanced-custom-fields/acf.php' ) && ! is_plugin_active( 'advanced-custom-fields-pro/acf.php' ) ) {
+			add_action( 'admin_notices', array( $this, 'require_acf' ) );
+			deactivate_plugins( plugin_basename( __FILE__ ) );
+
+			if ( isset( $_GET['activate'] ) ) {
+				unset( $_GET['activate'] );
 			}
 		}
 	}
-	
+
 	public function require_acf() { ?>
-		<div class="error"><p><?php _e('ACF Native Fields requires Advanced Custom Fields v5+ to be installed and activated.', 'acf-native-fields'); ?></p></div><?php
+		<div class="error"><p><?php esc_html_e( 'ACF Native Fields requires Advanced Custom Fields v5+ to be installed and activated.', 'acf-native-fields' ); ?></p></div>
+		<?php
 	}
-	
+
 	public function include_native_field_type() {
-		require(dirname(__FILE__) . '/acf-native-field-type.php');
-		
+		require dirname( __FILE__ ) . '/acf-native-field-type.php';
+
 		new acf_field_native();
 	}
-	
-	 static function &instance() { 
-		if(false === self::$instance) { 
-			self::$instance = new ACF_Native_Fields(); 
+
+	static function &instance() {
+		if ( false === self::$instance ) {
+			self::$instance = new ACF_Native_Fields();
 		}
-		
-		return self::$instance; 
-	} 
+
+		return self::$instance;
+	}
 }
 
 new ACF_Native_Fields();

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,138 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "b17a2a17da67c2c2c397c6de7e91ec23",
+    "packages": [
+        {
+            "name": "composer/installers",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/installers.git",
+                "reference": "cfcca6b1b60bc4974324efb5783c13dca6932b5b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/installers/zipball/cfcca6b1b60bc4974324efb5783c13dca6932b5b",
+                "reference": "cfcca6b1b60bc4974324efb5783c13dca6932b5b",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0"
+            },
+            "replace": {
+                "roundcube/plugin-installer": "*",
+                "shama/baton": "*"
+            },
+            "require-dev": {
+                "composer/composer": "1.0.*@dev",
+                "phpunit/phpunit": "^4.8.36"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Composer\\Installers\\Plugin",
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Installers\\": "src/Composer/Installers"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kyle Robinson Young",
+                    "email": "kyle@dontkry.com",
+                    "homepage": "https://github.com/shama"
+                }
+            ],
+            "description": "A multi-framework Composer library installer",
+            "homepage": "https://composer.github.io/installers/",
+            "keywords": [
+                "Craft",
+                "Dolibarr",
+                "Eliasis",
+                "Hurad",
+                "ImageCMS",
+                "Kanboard",
+                "Lan Management System",
+                "MODX Evo",
+                "Mautic",
+                "Maya",
+                "OXID",
+                "Plentymarkets",
+                "Porto",
+                "RadPHP",
+                "SMF",
+                "Thelia",
+                "WolfCMS",
+                "agl",
+                "aimeos",
+                "annotatecms",
+                "attogram",
+                "bitrix",
+                "cakephp",
+                "chef",
+                "cockpit",
+                "codeigniter",
+                "concrete5",
+                "croogo",
+                "dokuwiki",
+                "drupal",
+                "eZ Platform",
+                "elgg",
+                "expressionengine",
+                "fuelphp",
+                "grav",
+                "installer",
+                "itop",
+                "joomla",
+                "kohana",
+                "laravel",
+                "lavalite",
+                "lithium",
+                "magento",
+                "majima",
+                "mako",
+                "mediawiki",
+                "modulework",
+                "modx",
+                "moodle",
+                "osclass",
+                "phpbb",
+                "piwik",
+                "ppi",
+                "puppet",
+                "pxcms",
+                "reindex",
+                "roundcube",
+                "shopware",
+                "silverstripe",
+                "sydes",
+                "symfony",
+                "typo3",
+                "wordpress",
+                "yawik",
+                "zend",
+                "zikula"
+            ],
+            "time": "2018-08-27T06:10:37+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/css/acf-native-fields-admin.css
+++ b/css/acf-native-fields-admin.css
@@ -1,4 +1,5 @@
 /* Hide name for native fields */
-.acf-field-object-native-field tr[data-name="name"], .acf-field-object-native-field tr[data-name="required"] {
-	display: none!important;
+.acf-field-object-native-field tr[data-name="name"],
+.acf-field-object-native-field tr[data-name="required"] {
+  display: none !important;
 }

--- a/css/acf-native-fields.css
+++ b/css/acf-native-fields.css
@@ -1,31 +1,31 @@
 /* Remove styling from postboxes (new class added to them with JS) */
-.native-field-postbox  .inside {
-	margin: 0;
-	padding: 0;
+.native-field-postbox .inside {
+  margin: 0;
+  padding: 0;
 }
 
-/* Remove styling from WYSIWYG editor*/
-.acf-native-field .wp-editor-wrap  {
-	margin-top: -20px;
+/* Remove styling from WYSIWYG editor */
+.acf-native-field .wp-editor-wrap {
+  margin-top: -20px;
 }
 
 /* Hide default excerpt description */
 .acf-native-field #postexcerpt p {
-	display: none;
+  display: none;
 }
 
-.acf-native-field  #wp-content-editor-tools  {
-	border: none;
-	background: none;
+.acf-native-field #wp-content-editor-tools {
+  border: none;
+  background: none;
 }
 
 /* Remove styling from publishing actions */
 .acf-native-field #major-publishing-actions {
-	border: none;
-	background: none;
+  border: none;
+  background: none;
 }
 
 /* Hide postbox header */
 .acf-native-field h2 {
-	display: none;
+  display: none;
 }

--- a/js/acf-native-fields.js
+++ b/js/acf-native-fields.js
@@ -9,7 +9,7 @@
 		init: function() {
 			ACF_Native_Fields.editor_container = $('#post-body');
 			ACF_Native_Fields.native_fields = ACF_Native_Fields.editor_container.find('.acf-native-field');
-			
+
 			// Move all native fields into their placeholders
 			ACF_Native_Fields.moveNativeFields();
 		},
@@ -150,7 +150,7 @@
 		 * ACF Native Field type: custom
 		 */
 		moveNativeField_custom: function (native_field_placeholder) {
-			return ACF_Native_Fields.getNativeFieldElement('#' + native_field_placeholder.data('metabox-id'));
+			return ACF_Native_Fields.getNativeFieldElement(native_field_placeholder.data('metabox-id'));
 		},
 	};
 

--- a/js/acf-native-fields.js
+++ b/js/acf-native-fields.js
@@ -60,10 +60,50 @@
 		moveNativeField: function() {
 			var native_field_placeholder = $(this).empty();
 			var native_field_type = native_field_placeholder.data('native-field');
+			var native_fields = {
+				// Core
+				content: '#postdivrich',
+				excerpt: '#postexcerpt',
+				publish_box: '#submitdiv',
+				page_attributes: '#pageparentdiv',
+				featured_image: '#postimagediv',
+
+				permalink: '#slugdiv',
+				author: '#authordiv',
+
+				categories: '#categorydiv',
+				tags: '#tagsdiv-post_tag',
+				format: '#formatdiv',
+
+				revisions: '#revisionsdiv',
+				comments: '#commentsdiv',
+				discussion: '#commentstatusdiv',
+				trackbacks: '#trackbacksdiv',
+
+				// WooCommerce
+				all: '#product_catdiv, #tagsdiv-product_tag, #postimagediv, #woocommerce-product-images, #woocommerce-product-data, #postexcerpt, #commentsdiv',
+				product_categories: '#product_catdiv',
+				product_tags: '#tagsdiv-product_tag',
+				product_image: '#postimagediv', // Core Duplicate
+				product_gallery: '#woocommerce-product-images',
+				product_data: '#woocommerce-product-data',
+				product_short_description: '#postexcerpt', // Core Duplicate
+				reviews: '#commentsdiv', // Core Duplicate
+
+				// Plugins
+				yoast_seo: '#wpseo_meta',
+				seo_framework: '#tsf-inpost-box',
+				classic_editor: '#classic-editor-switch-editor',
+				laygridder: '#gridder, #gridder-modals',
+
+				// Custom
+				custom: native_field_placeholder.data('metabox-id'),
+			}
 
 			// First try to find a built-in method to run for this type of native field
-			if(typeof ACF_Native_Fields['moveNativeField_' + native_field_type] === 'function') {
-				native_field_placeholder.append(ACF_Native_Fields['moveNativeField_' + native_field_type](native_field_placeholder));
+			if(native_fields[native_field_type]) {
+				var native_field = ACF_Native_Fields.getNativeFieldElement(native_fields[native_field_type]);
+				native_field_placeholder.append(native_field);
 				// TODO: Allow custom callback code to be added in field group settings and executed here?
 			}
 			// If none exists, see if a custom one has been passed, and exists
@@ -74,83 +114,6 @@
 			else {
 				native_field_placeholder.html(acf._e('native_field', 'not_implemented'));
 			}
-		},
-
-		/**
-		 * ACF Native Field type: WordPress content editor
-		 */
-		moveNativeField_content: function() {
-			return ACF_Native_Fields.getNativeFieldElement('#postdivrich');
-		},
-
-		/**
-		 * ACF Native Field type: WordPress excerpt editor
-		 */
-		moveNativeField_excerpt: function() {
-			return ACF_Native_Fields.getNativeFieldElement('#postexcerpt');
-		},
-
-		/**
-		 * ACF Native Field type: WordPress featured image
-		 */
-		moveNativeField_featured_image: function() {
-			return ACF_Native_Fields.getNativeFieldElement('#postimagediv');
-		},
-
-		/**
-		 * ACF Native Field type: SEO meta box (Yoast or SEO framework)
-		 */
-		moveNativeField_yoast_seo: function() {
-			return ACF_Native_Fields.getNativeFieldElement('#wpseo_meta, #tsf-inpost-box');
-		},
-
-		/**
-		 * ACF Native Field type: WordPress publish meta box
-		 */
-		moveNativeField_publish_box: function() {
-			return ACF_Native_Fields.getNativeFieldElement('#submitdiv');
-		},
-
-		/**
-		 * ACF Native Field type: WordPress permalink meta box
-		 */
-		moveNativeField_permalink: function() {
-			return ACF_Native_Fields.getNativeFieldElement('#slugdiv');
-		},
-
-		/**
-		 * ACF Native Field type: WordPress discussion settings meta box
-		 */
-		moveNativeField_discussion: function() {
-			return ACF_Native_Fields.getNativeFieldElement('#commentstatusdiv');
-		},
-
-		/**
-		 * ACF Native Field type: WordPress trackback settings meta box
-		 */
-		moveNativeField_trackbacks: function() {
-			return ACF_Native_Fields.getNativeFieldElement('#trackbacksdiv');
-		},
-
-		/**
-		 * ACF Native Field type: WordPress post format meta box
-		 */
-		moveNativeField_format: function() {
-			return ACF_Native_Fields.getNativeFieldElement('#formatdiv');
-		},
-
-		/**
-		 * ACF Native Field type: WordPress page attributes meta box
-		 */
-		moveNativeField_page_attributes: function() {
-			return ACF_Native_Fields.getNativeFieldElement('#pageparentdiv');
-		},
-
-		/**
-		 * ACF Native Field type: custom
-		 */
-		moveNativeField_custom: function (native_field_placeholder) {
-			return ACF_Native_Fields.getNativeFieldElement(native_field_placeholder.data('metabox-id'));
 		},
 	};
 


### PR DESCRIPTION
This PR adds most of the default native fields discussed in #3.

## **Breaking Changes**
- The _Custom_ option now requires you to write a valid CSS selector instead of just the ID of the element. This change has been introduced to explicitly acknowledge users can select multiple metaboxes to move at once. Previously it would've required them to write something like `first-id, #second-id`.

## Other Changes
- Options inside the native `select` element are now grouped by category (Core, WooCommerce, Plugins, and Other)
- Options from the WooCommerce and Plugins categories are now shown only when the required plugin is active (not just installed)
- Instead of having a common option for both Yoast SEO and The SEO Framework, they now have independent options